### PR TITLE
Remove version from ansible metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,7 +11,6 @@ galaxy_info:
   categories:
     - cloud
     - system
-    - platform 
+    - platform
 
 dependencies: []
-version: 0.0.2


### PR DESCRIPTION
Currently Ansible 2 fails to work with `version` in the meta file. I can't see
it listed anywhere in the documentation so is safe to remove without breaking
backward compatibility.

Yasser
