### PR TITLE
Added become statements and http(s) proxy support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 # Options passed to the docker daemon at start
 docker_opts: ""
+docker_http_proxy: ""
+docker_https_proxy: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,29 +2,34 @@
   template:
     src: docker-main.repo.j2
     dest: /etc/yum.repos.d/docker-main.repo
+  become: true
 
 - name: create systemd override directory
   file:
     path: /etc/systemd/system/docker.service.d
     state: directory
   when: ansible_distribution_major_version == "7"
+  become: true
 
 - name: add systemd override
   copy:
     src: override.conf
     dest: /etc/systemd/system/docker.service.d/override.conf
   when: ansible_distribution_major_version == "7"
+  become: true
 
 - name: install docker
   yum:
     name: docker-engine
     state: present
   register: docker_install
+  become: true
 
 - name: create sysconfig file
   template:
     src: sysconfig.j2
     dest: /etc/sysconfig/docker
+  become: true
 
 # Prefer when|changed over a notification so these run ASAP
 - name: restart cgconfig on rhel6
@@ -34,9 +39,11 @@
   when:
     - docker_install|changed
     - ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
+  become: true
 
 - name: start and enable docker
   service:
     name: docker
     state: started
     enabled: yes
+  become: true

--- a/templates/sysconfig.j2
+++ b/templates/sysconfig.j2
@@ -3,3 +3,9 @@ DOCKER_OPTS="{{ docker_opts }}"
 {% elif ansible_distribution_major_version == "6" %}
 other_args="{{ docker_opts }}"
 {% endif %}
+{% if docker_http_proxy %}
+HTTP_PROXY="{{ docker_http_proxy }}"
+{% endif %}
+{% if docker_https_proxy %}
+HTTPS_PROXY="{{ docker_https_proxy }}"
+{% endif %}


### PR DESCRIPTION
I've added become statements for the tasks in case we're not running Ansible as root and not using _sudo_. 
Second change enables http(s) proxy setting for installations behind proxy. 
