### PR TITLE
Add docker_env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,25 @@
 
 This role installs the latest version of Docker from the official Docker repositories. All the other roles I've found seemed to be way more opinionated. This one just installs `docker-engine`, starts the service, then leaves you alone. Good day sir.
 
-## Configurations
+## Role Variables
 
  * `docker_opts` - Arguments passed to the docker daemon at start time
+ * `docker_env` - Dictionary of environment variables to set for the docker daemon
+
+## Common Settings
+
+### Using an HTTP(S) proxy with Docker
+
+Use the `docker_env` variable to set the `HTTP_PROXY` and/or `HTTPS_PROXY` environment variables:
+
+``` yaml
+- hosts: all
+  roles:
+    - role: DavidWittman.docker
+      docker_env:
+        HTTP_PROXY: "http://127.0.0.1:8080"
+        HTTPS_PROXY: "https://127.0.0.1:8080"
+```
 
 ## Testing
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 # Options passed to the docker daemon at start
 docker_opts: ""
+# Dictionary of variables to set in the docker daemon's environment
+docker_env: {}

--- a/templates/sysconfig.j2
+++ b/templates/sysconfig.j2
@@ -1,5 +1,12 @@
 {% if ansible_distribution_major_version == "7" %}
 DOCKER_OPTS="{{ docker_opts }}"
+{% for k,v in docker_env.iteritems() %}
+{{ k }}="{{ v }}"
+{% endfor %}
 {% elif ansible_distribution_major_version == "6" %}
 other_args="{{ docker_opts }}"
+{# We need to export environment variables on RHEL 6 #}
+{% for k,v in docker_env.iteritems() %}
+export {{ k }}="{{ v }}"
+{% endfor %}
 {% endif %}


### PR DESCRIPTION
Permits for setting environment variables for the docker daemon.
Among other things, this can be used for setting the HTTP(S) proxy as
documented in the README.

Thanks @mprasil for originally addressing this issue in #4.

Closes #5
